### PR TITLE
Use gksudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 * 如果觉得上述方法过于繁琐,可以使用Hosts自动配置工具一键完成<br>**下载地址:[http://pan.baidu.com/s/1bnrPn1l](http://pan.baidu.com/s/1bnrPn1l)**
 
 ## GNU/Linux 
-* 以Ubuntu为例,终端输入`sudo gedit /etc/hosts`,然后把[hosts](https://github.com/racaljk/hosts_for_google_service/blob/master/hosts) 中的代码复制到hosts文件中覆盖里面的内容，保存即可。
+* 以Ubuntu为例,终端输入`gksudo gedit /etc/hosts`,然后把[hosts](https://github.com/racaljk/hosts_for_google_service/blob/master/hosts) 中的代码复制到hosts文件中覆盖里面的内容，保存即可。
 
-##Others
+## Others
 * hosts自动配置工具使用C++构建,GUI基于Qt,源码遵守GPL协议发布
 * 如果这个项目没来得及更新,也可以访问下面的链接获取最新hosts文件<br>
 [oschina](http://git.oschina.net/jiange1236/googlehosts/) | [Acrylated](https://github.com/LGA1150/Acrylated-imouto.host/blob/master/AcrylicHosts.txt) 


### PR DESCRIPTION
gedit is a GUI application, and GUI applications should use gksudo because of config path, etc.