### PR TITLE
hosts: 更换Google.cn为国内IP，优化Twitter相关服务连接

### DIFF
--- a/hosts
+++ b/hosts
@@ -1562,7 +1562,7 @@ fe80::1%lo0	localhost
 
 # Gmail Start
 103.7.200.79	b.googlemail.l.google.com 
-103.7.200.79	chatenabled.mail.google.com 
+# 103.7.200.79	chatenabled.mail.google.com 
 103.7.200.79	filetransferenabled.mail.google.com 
 103.7.200.79	gmail.com 
 103.7.200.79	gmail.google.com 
@@ -1587,8 +1587,9 @@ fe80::1%lo0	localhost
 # Gmail End
 
 # Google Zip 
-74.125.201.211	proxy.googlezip.net 
-74.125.201.212	check.googlezip.net 
+216.58.221.76	googlezip.net
+64.233.189.211	proxy.googlezip.net 
+64.233.189.211	check.googlezip.net 
   
 # Google Accounts
 103.7.200.79	contacts.google.com
@@ -2236,7 +2237,7 @@ fe80::1%lo0	localhost
 103.7.200.79	bks8.books.google.com.hk 
 103.7.200.79	bks9.books.google.com 
 103.7.200.79	bks9.books.google.com.hk 
-103.7.200.79	books.google.cn 
+203.208.50.134	books.google.cn 
 103.7.200.79	books.google.co.jp 
 103.7.200.79	books.google.com 
 103.7.200.79	books.google.com.hk 
@@ -2862,7 +2863,7 @@ fe80::1%lo0	localhost
   
   
 # Google Maps	 
-103.7.200.79	ditu.google.cn 
+203.208.50.134	ditu.google.cn 
 103.7.200.79	ditu.google.com 
 103.7.200.79	gmaps-samples-flash.googlecode.com 
 103.7.200.79	gsamplemaps.googlepages.com 
@@ -2870,7 +2871,7 @@ fe80::1%lo0	localhost
 103.7.200.79	juliamap.googlelabs.com 
 103.7.200.79	map.google.com 
 103.7.200.79	maps.gmodules.com 
-103.7.200.79	maps.google.cn 
+203.208.50.134	maps.google.cn 
 103.7.200.79	maps.google.co.jp 
 103.7.200.79	maps.google.com 
 103.7.200.79	maps.google.com.hk 
@@ -3021,7 +3022,7 @@ fe80::1%lo0	localhost
 103.7.200.79	blog.orkut.com 
 103.7.200.79	blog.panoramio.com 
 103.7.200.79	blog.webmproject.org 
-103.7.200.79	blogsearch.google.cn 
+203.208.50.134	blogsearch.google.cn 
 103.7.200.79	blogsearch.google.co.jp 
 103.7.200.79	blogsearch.google.com 
 103.7.200.79	blogsearch.google.com.hk 
@@ -3093,7 +3094,7 @@ fe80::1%lo0	localhost
 103.7.200.79	en.blog.orkut.com 
 103.7.200.79	evolutionofweb.appspot.com 
 103.7.200.79	fastflip.googlelabs.com 
-103.7.200.79	feedads.g.doubleclick.net 
+203.208.50.141	feedads.g.doubleclick.net 
 103.7.200.79	feedburner.google.com 
 103.7.200.79	feedproxy.google.com 
 103.7.200.79	feeds.feedburner.com 
@@ -3113,7 +3114,7 @@ fe80::1%lo0	localhost
 103.7.200.79	gderekwei.appspot.com 
 103.7.200.79	geoauth.google.com 
 103.7.200.79	gfwrev.blogspot.com 
-103.7.200.79	gg.google.cn 
+203.208.50.134	gg.google.cn 
 103.7.200.79	gg.google.com 
 103.7.200.79	ghs.google.com 
 103.7.200.79	ghs.l.google.com 
@@ -3125,10 +3126,10 @@ fe80::1%lo0	localhost
 103.7.200.79	golang.org 
 103.7.200.79	goo.gl 
 103.7.200.79	googcloudlabs.appspot.com 
-103.7.200.79	google.cn 
+203.208.50.134	google.cn 
 103.7.200.79	google.com 
 103.7.200.79	google.com.hk 
-103.7.200.79	googleads.g.doubleclick.net 
+203.208.50.141	googleads.g.doubleclick.net 
 103.7.200.79	googleappengine.googlecode.com 
 103.7.200.79	googleblog.blogspot.com 
 103.7.200.79	googlechinablog.blogspot.com 
@@ -3143,7 +3144,7 @@ fe80::1%lo0	localhost
 103.7.200.79	googlesystem.blogspot.com 
 103.7.200.79	goto.ext.google.com 
 103.7.200.79	goto.google.com 
-103.7.200.79	groups.google.cn 
+203.208.50.134	groups.google.cn 
 103.7.200.79	groups.google.co.jp 
 103.7.200.79	groups.google.com 
 103.7.200.79	groups.google.com.hk 
@@ -3167,7 +3168,7 @@ fe80::1%lo0	localhost
 103.7.200.79	huhamhire-hosts.googlecode.com 
 103.7.200.79	hwswbits.blogspot.com 
 103.7.200.79	hx-in-f117.1e100.net 
-103.7.200.79	id.google.cn 
+203.208.50.134	id.google.cn 
 103.7.200.79	id.google.com 
 103.7.200.79	id.google.com.co.jp 
 103.7.200.79	id.google.com.hk 
@@ -3222,7 +3223,7 @@ fe80::1%lo0	localhost
 103.7.200.79	lists.webmproject.org 
 103.7.200.79	livingstories.googlelabs.com 
 103.7.200.79	local.google.com 
-103.7.200.79	m.google.cn 
+203.208.50.134	m.google.cn 
 103.7.200.79	m.google.com 
 103.7.200.79	m.google.com.co.jp 
 103.7.200.79	m.google.com.hk 
@@ -3237,16 +3238,16 @@ fe80::1%lo0	localhost
 103.7.200.79	mobile.l.google.com 
 103.7.200.79	mobile-gtalk.l.google.com 
 103.7.200.79	moderator.appspot.com 
-103.7.200.79	mt.google.cn 
+203.208.50.134	mt.google.cn 
 103.7.200.79	mt.google.com 
 103.7.200.79	mt.l.google.com 
-103.7.200.79	mt0.google.cn 
+203.208.50.134	mt0.google.cn 
 103.7.200.79	mt0.google.com 
-103.7.200.79	mt1.google.cn 
+203.208.50.134	mt1.google.cn 
 103.7.200.79	mt1.google.com 
-103.7.200.79	mt2.google.cn 
+203.208.50.134	mt2.google.cn 
 103.7.200.79	mt2.google.com 
-103.7.200.79	mt3.google.cn 
+203.208.50.134	mt3.google.cn 
 103.7.200.79	mt3.google.com 
 103.7.200.79	mts.google.com 
 103.7.200.79	mts.l.google.com 
@@ -3260,7 +3261,7 @@ fe80::1%lo0	localhost
 103.7.200.79	mw1.google.com 
 103.7.200.79	mw2.google.com 
 103.7.200.79	mytracks.appspot.com 
-103.7.200.79	news.google.cn 
+203.208.50.134	news.google.cn 
 103.7.200.79	news.google.co.jp 
 103.7.200.79	news.google.com 
 103.7.200.79	news.google.com.hk 
@@ -3280,7 +3281,7 @@ fe80::1%lo0	localhost
 103.7.200.79	orkut-static.l.google.com 
 103.7.200.79	p.gmodules.com 
 103.7.200.79	p2-bvqou66hg26j6-gcqu446vkvy6alxg-if-v6exp3-v4.metric.gstatic.com 
-103.7.200.79	pack.google.cn 
+203.208.50.134	pack.google.cn 
 103.7.200.79	pack.google.com 
 103.7.200.79	pagead.google.com 
 103.7.200.79	pagead.l.google.com 
@@ -3342,7 +3343,7 @@ fe80::1%lo0	localhost
 103.7.200.79	project-slingshot-gp.appspot.com 
 103.7.200.79	promote.orkut.com 
 103.7.200.79	proxytea.appspot.com 
-103.7.200.79	pubads.g.doubleclick.net 
+203.208.50.141	pubads.g.doubleclick.net 
 103.7.200.79	r2303.latest.project-slingshot-hr.appspot.com 
 103.7.200.79	r3085-dot-latest-dot-project-slingshot-gp.appspot.com 
 103.7.200.79	r3091-dot-latest-dot-project-slingshot-gp.appspot.com 
@@ -3366,7 +3367,7 @@ fe80::1%lo0	localhost
 103.7.200.79	sb.l.google.com 
 103.7.200.79	sb-ssl.google.com 
 103.7.200.79	sb-ssl.l.google.com 
-103.7.200.79	scholar.google.cn 
+203.208.50.134	scholar.google.cn 
 103.7.200.79	scholar.google.co.jp 
 103.7.200.79	scholar.google.com 
 103.7.200.79	scholar.google.com.hk 
@@ -3451,7 +3452,7 @@ fe80::1%lo0	localhost
 103.7.200.79	tools.l.google.com
 103.7.200.79	toolbox.googleapps.com
 103.7.200.79	eduproducts.withgoogle.com
-103.7.200.79	translate.google.cn 
+203.208.50.134	translate.google.cn 
 103.7.200.79	translate.google.co.jp 
 103.7.200.79	translate.google.com 
 103.7.200.79	translate.google.com.hk 
@@ -3803,25 +3804,25 @@ fe80::1%lo0	localhost
 
 # Twitter Start
 185.45.5.36	t.co
-185.45.5.44	api.twitter.com
-199.96.57.2	a0.twimg.com
-199.96.57.2	a1.twimg.com
+199.59.150.48	api.twitter.com
+199.59.150.6	a0.twimg.com
+199.59.150.6	a1.twimg.com
 185.45.5.34	about.twitter.com
-199.96.57.2	abs.twimg.com
+199.59.150.6	abs.twimg.com
 199.16.158.182	api.tweetdeck.com
 185.45.5.34	betastream.twitter.com
 185.45.5.34	blog.twitter.com
-192.229.237.25	cdn.api.twitter.com
-199.16.158.175	cdn.syndication.twimg.com
+199.59.150.48	cdn.api.twitter.com
+199.59.150.6	cdn.syndication.twimg.com
 199.16.158.175	cdn.syndication.twitter.com
 185.45.5.34	dev.twitter.com
 199.16.158.182	downloads.tweetdeck.com
-199.96.57.2	g.twimg.com
-199.16.156.17	image-proxy-origin.twimg.com
+199.59.150.6	g.twimg.com
+199.59.150.6	image-proxy-origin.twimg.com
 173.236.110.98	m1.twitpic.com
-117.18.237.172	ma.twimg.com
+199.59.150.6	ma.twimg.com
 199.16.158.173	mobile.twitter.com
-199.96.57.2	o.twimg.com
+199.59.150.6	o.twimg.com
 209.17.68.209	oi40.tinypic.com
 209.17.68.209	oi41.tinypic.com
 209.17.68.209	oi42.tinypic.com
@@ -3839,33 +3840,33 @@ fe80::1%lo0	localhost
 209.17.68.209	oi54.tinypic.com
 209.17.68.209	oi55.tinypic.com
 209.17.68.209	oi56.tinypic.com
-199.96.57.2	p.twimg.com
-199.96.57.2	pbs.twimg.com
+199.59.150.6	p.twimg.com
+199.59.150.6	pbs.twimg.com
 185.45.5.34	pic.twitter.com
 192.229.237.25	platform.twitter.com
 192.229.237.25	preview.cdn.twitter.com
 199.16.158.15	r.twimg.com
-199.96.57.2	si0.twimg.com
-199.96.57.2	si1.twimg.com
-199.96.57.2	si2.twimg.com
-199.96.57.2	si3.twimg.com
-199.96.57.2	si4.twimg.com
-199.96.57.2	si5.twimg.com
+199.59.150.6	si0.twimg.com
+199.59.150.6	si1.twimg.com
+199.59.150.6	si2.twimg.com
+199.59.150.6	si3.twimg.com
+199.59.150.6	si4.twimg.com
+199.59.150.6	si5.twimg.com
 185.45.5.34	sitestream.twitter.com
 185.45.5.34	stream.twitter.com
 199.16.158.185	support.twitter.com
-199.16.158.175	syndication.twimg.com
+199.59.150.6	syndication.twimg.com
 199.16.158.175	syndication.twitter.com
-199.16.158.175	syndication-o.twimg.com
+199.59.150.6	syndication-o.twimg.com
 199.16.158.175	syndication-o.twitter.com
 199.16.158.182	tdweb.twitter.com
-199.96.57.2	ton.twimg.com
+199.59.150.6	ton.twimg.com
 199.16.158.182	tweetdeck.com
 199.16.158.182	tweetdeck.twitter.com
 173.236.110.98	twitpic.com
 185.45.5.32	twitter.com
 199.16.158.187	upload.twitter.com
-95.211.220.155	urls-real.api.twitter.com
+199.59.150.48	urls-real.api.twitter.com
 108.61.13.60	userstream.twitter.com
 199.16.158.182	web.tweetdeck.com
 173.236.110.98	web1.twitpic.com


### PR DESCRIPTION
Google.cn不需翻墙，所以无需使用国外源代理
打开Google.cn的翻译和地图，明显速度有很大提升

C:\Users\Administrator>ping translate.google.cn

正在 Ping translate.google.cn [203.208.50.134] 具有 32 字节的数据:
来自 203.208.50.134 的回复: 字节=32 时间=26ms TTL=127
来自 203.208.50.134 的回复: 字节=32 时间=27ms TTL=127
来自 203.208.50.134 的回复: 字节=32 时间=26ms TTL=127
来自 203.208.50.134 的回复: 字节=32 时间=29ms TTL=127

203.208.50.134 的 Ping 统计信息:
    数据包: 已发送 = 4，已接收 = 4，丢失 = 0 (0% 丢失)，
往返行程的估计时间(以毫秒为单位):
    最短 = 26ms，最长 = 29ms，平均 = 27ms