### PR TITLE
自动拷贝hosts到Windows的etc目录下，并增加自动备份功能

### DIFF
--- a/hosts_tools/scripts/script_tool_for_windows.bat
+++ b/hosts_tools/scripts/script_tool_for_windows.bat
@@ -18,6 +18,9 @@ REM ________________________________________________________________
 echo -----------------------------------------------------------
 echo https://github.com/racaljk/hosts
 echo -----------------------------------------------------------
+echo Backup hosts ...
+copy "%SystemRoot%\System32\drivers\etc\hosts" "%SystemRoot%\System32\drivers\etc\hosts-%date%-%time::=-%"
+echo -----------------------------------------------------------
 :: flush DNS before copy or after copy???
 :: I think it's same.
 ipconfig /flushdns

--- a/hosts_tools/scripts/script_tool_for_windows.bat
+++ b/hosts_tools/scripts/script_tool_for_windows.bat
@@ -14,5 +14,17 @@ if exist "%temp%\getadmin.vbs" ( del "%temp%\getadmin.vbs" )
 pushd "%CD%"
 CD /D "%~dp0"
 REM ________________________________________________________________
-start %SystemRoot%\notepad.exe "%SystemRoot%\System32\drivers\etc\hosts"
-exit
+::start %SystemRoot%\notepad.exe "%SystemRoot%\System32\drivers\etc\hosts"
+echo -----------------------------------------------------------
+echo https://github.com/racaljk/hosts
+echo -----------------------------------------------------------
+:: flush DNS before copy or after copy???
+:: I think it's same.
+ipconfig /flushdns
+echo -----------------------------------------------------------
+echo Begin to copy hosts ...
+copy "%~dp0..\..\hosts" "%SystemRoot%\System32\drivers\etc\hosts"
+:: pause for user to see what's going on
+:: in case of someone see a black window flash away
+:: and report it to Github issues.
+pause


### PR DESCRIPTION
The bat before just open hosts in notepad with administrator privilege
so the user have to copy the content by themselves.