### PR TITLE
Fix DriveNotepad for Gdrive

### DIFF
--- a/hosts
+++ b/hosts
@@ -662,6 +662,8 @@ static.ak.fbcdn.net    origincache-starfacebook-ai-01-05-ash3.facebook.com
 220.255.2.153	spreadsheets7.google.com
 220.255.2.153	spreadsheets8.google.com
 220.255.2.153	spreadsheets9.google.com
+220.255.2.153	drivenotepad.appspot.com
+220.255.2.153	8c953efe117cb4ee14eaffe2b417623a104ce4e6.googledrive.com
 220.255.2.153	v3.cache1.c.docs.google.com
 220.255.2.153	domains.google.com
 220.255.2.153	dl-ssl.google.com


### PR DESCRIPTION
Fix Drive Notepad for Google drive. Drive Notepad is to edit the text files in your Google drive online.