### PR TITLE
用powershell脚本来代替bat

### DIFF
--- a/hosts_tools/scripts/script_tool_for_windows.ps1
+++ b/hosts_tools/scripts/script_tool_for_windows.ps1
@@ -1,0 +1,2 @@
+
+Start-Process "$psHome\powershell.exe"   -ArgumentList "if (Test-Path C:\Windows\System32\drivers\etc\hosts){Copy-Item C:\Windows\System32\drivers\etc\hosts C:\Windows\System32\drivers\etc\hosts.bak}; Invoke-RestMethod -uri https://raw.githubusercontent.com/racaljk/hosts/master/hosts -method get > C:\Windows\System32\drivers\etc\hosts"   -verb runas


### PR DESCRIPTION
用更简洁的powershell脚本来完成hosts的更换，原hosts会被备份到host目录下的hosts.bak文件中。