### PR TITLE
解决flickr不能下载的问题

### DIFF
--- a/hosts
+++ b/hosts
@@ -3626,6 +3626,7 @@ fe80::1%lo0	localhost
 98.138.47.63	y.analytics.yahoo.com
 98.138.253.109	yahoo.com
 77.238.184.150	ying.com
+183.177.81.75	downloadr.flickr.com
 # Yahoo End
 
 # Travis CI fastly CDN Start


### PR DESCRIPTION
解决flickr不能下载的问题，添加了downloadr.flickr.com的地址