### PR TITLE
Add for github static resources

### DIFF
--- a/hosts
+++ b/hosts
@@ -3681,8 +3681,8 @@ fe80::1%lo0	localhost
 # Travis CI fastly CDN End
 
 # Github start
-192.30.252.141	gist.github.com
-#185.31.17.184 	github.global.ssl.fastly.net
+192.30.252.141  gist.github.com
+#185.31.17.184  github.global.ssl.fastly.net
 103.245.222.184 github.global.ssl.fastly.net
 # Github end
 

--- a/hosts
+++ b/hosts
@@ -3682,6 +3682,8 @@ fe80::1%lo0	localhost
 
 # Github start
 192.30.252.141	gist.github.com
+#185.31.17.184 	github.global.ssl.fastly.net
+103.245.222.184 github.global.ssl.fastly.net
 # Github end
 
 #TensorFlow start


### PR DESCRIPTION
sometimes the github.com’s static resource(such as css&js ) can't download,we will get a ugly page(only html) ,use this can download normally.

