### PR TITLE
Add hosts of Line

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-06-22
+# Last updated: 2016-06-23
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -3744,5 +3744,18 @@ fe80::1%lo0	localhost
 103.28.248.96	www.smartdnsproxy.com
 184.72.50.35	support.smartdnsproxy.com
 # Smartdnsproxy end
+
+# Line Start
+182.92.24.51  gd2w.line.naver.jp
+184.25.56.204 dl.profile.line.naver.jp
+184.25.56.162 dl.stickershop.line.naver.jp
+119.235.235.84  gd2.line.naver.jp
+125.209.252.11	gd2g.line.naver.jp
+125.209.254.13	gd2i.line.naver.jp
+125.209.222.202	gd2k.line.naver.jp
+125.209.254.33	gd2s.line.naver.jp
+203.104.160.11	gd2u.line.naver.jp
+113.52.56.21	gd2v.line.naver.jp
+# Line End
 
 # Modified hosts end


### PR DESCRIPTION
One of the project with a customer in Korean requires to Line for daily communications, while found it had been banned by GFW long ago...not sure if there are some some Line users in China mainland as of today...

You may deny the PR if it is not that useful for most of the users.