### PR TITLE
REMOVED: hosts of LINE

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-06-24
+# Last updated: 2016-06-25
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/hosts
+++ b/hosts
@@ -3745,17 +3745,4 @@ fe80::1%lo0	localhost
 184.72.50.35	support.smartdnsproxy.com
 # Smartdnsproxy end
 
-# Line Start
-182.92.24.51	gd2w.line.naver.jp
-184.25.56.204	dl.profile.line.naver.jp
-184.25.56.162	dl.stickershop.line.naver.jp
-119.235.235.84	gd2.line.naver.jp
-125.209.252.11	gd2g.line.naver.jp
-125.209.254.13	gd2i.line.naver.jp
-125.209.222.202	gd2k.line.naver.jp
-125.209.254.33	gd2s.line.naver.jp
-203.104.160.11	gd2u.line.naver.jp
-113.52.56.21	gd2v.line.naver.jp
-# Line End
-
 # Modified hosts end


### PR DESCRIPTION
I am terribly sorry that I have to remove the hosts of LINE which I committed yesterday...found that simply adding hosts for it doesn't really help, any LINE ID associated with the phone numbers of China mainland, HK, Japan can not work properly in China mainland (even you could login and get connected, but you could not receive any message/update/invitation, etc.)...Hosts change won't solve the issue...it requires other tweaks instead.

Sorry again for the inconvenience.