### PR TITLE
W3Schools 上不去，应该加回来

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-06-25
+# Last updated: 2016-06-26
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -3693,8 +3693,8 @@ fe80::1%lo0	localhost
 #TensorFlow end
 
 # W3schools Start
-#68.232.44.251	w3schools.com
-#68.232.44.251	www.w3schools.com
+68.232.44.251	w3schools.com
+68.232.44.251	www.w3schools.com
 # W3schools End
 
 # Medium start


### PR DESCRIPTION
www.w3schools.com 上不去，把它前面的注释符号去掉