### PR TITLE
Github已不需要hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-07-21
+# Last updated: 2016-07-22
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -3719,10 +3719,6 @@ fe80::1%lo0	localhost
 # Travis CI fastly CDN Start
 103.245.222.249	travis-ci-org.global.ssl.fastly.net
 # Travis CI fastly CDN End
-
-# Github start
-192.30.253.119	gist.github.com
-# Github end
 
 #TensorFlow start
 64.233.188.121	www.tensorflow.org

--- a/hosts
+++ b/hosts
@@ -3720,6 +3720,10 @@ fe80::1%lo0	localhost
 103.245.222.249	travis-ci-org.global.ssl.fastly.net
 # Travis CI fastly CDN End
 
+# Github start
+# 192.30.253.119	gist.github.com
+# Github end
+
 #TensorFlow start
 64.233.188.121	www.tensorflow.org
 #TensorFlow end


### PR DESCRIPTION
Github已不需要hosts，故将它注释掉。
