### PR TITLE
fix 'gist.github.com' at Issue #535

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-07-17
+# Last updated: 2016-07-25
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -3715,7 +3715,7 @@ fe80::1%lo0	localhost
 # Travis CI fastly CDN End
 
 # Github start
-192.30.253.119	gist.github.com
+192.30.253.112	gist.github.com
 # Github end
 
 #TensorFlow start


### PR DESCRIPTION
修正一下 gist.github.com #535 