### PR TITLE
Add ipv4.google.com

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-09-05
+# Last updated: 2016-09-06
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -853,6 +853,7 @@ fe80::1%lo0	localhost
 220.255.2.153	cbks1.google.com
 220.255.2.153	cbks2.google.com
 220.255.2.153	cbks3.google.com
+220.255.2.153 ipv4.google.com
 220.255.2.153	mw1.google.com
 220.255.2.153	mw2.google.com
 220.255.2.153	mt.google.com


### PR DESCRIPTION
Today I visit Google as usual, but it automatically jump to an address, but it seems walled. I tried to add it on my local PC and enter the page.  (snapshot is below). So I come back to add a host.
---Snapshot: https://raw.githubusercontent.com/HzDSN/MyFirstProject/master/Add-ipv4.google.com.png