### PR TITLE
Add pixel.google.com

### DIFF
--- a/hosts
+++ b/hosts
@@ -907,7 +907,7 @@ fe80::1%lo0	localhost
 220.255.2.153	lh5.google.com
 220.255.2.153	lh6.google.com
 220.255.2.153	upload.photos.google.com
-220.255.2.153 pixel.google.com
+220.255.2.153  pixel.google.com
 220.255.2.153	profiles.google.com
 220.255.2.153	plusone.google.com
 220.255.2.153	plus.google.com

--- a/hosts
+++ b/hosts
@@ -907,6 +907,7 @@ fe80::1%lo0	localhost
 220.255.2.153	lh5.google.com
 220.255.2.153	lh6.google.com
 220.255.2.153	upload.photos.google.com
+220.255.2.153 pixel.google.com
 220.255.2.153	profiles.google.com
 220.255.2.153	plusone.google.com
 220.255.2.153	plus.google.com

--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-09-06
+# Last updated: 2016-09-10
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/


### PR DESCRIPTION
The news reports that Google will release two smartphones called 'pixel', but the site is still unable to access within hosts. This commit fixed it.