### PR TITLE
cancel onedrive hosts (取消掉onedrive的hosts)

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-09-13
+# Last updated: 2016-09-18
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/hosts
+++ b/hosts
@@ -3629,17 +3629,17 @@ fe80::1%lo0	localhost
 # MEGA End
 
 # OneDrive Start
-#65.55.163.79	account.live.com
+65.55.163.79	account.live.com
 #204.79.197.217	mail.live.com
-#23.59.136.70	auth.gfx.ms
-#131.253.61.66	login.live.com
-#204.79.197.217	onedrive.live.com
-#23.212.129.202	p.sfx.ms
-#134.170.30.15	people.live.com
-#134.170.30.15	profile.live.com
-#134.170.111.96	skyapi.onedrive.live.com
+23.59.136.70	auth.gfx.ms
+131.253.61.66	login.live.com
+204.79.197.217	onedrive.live.com
+23.212.129.202	p.sfx.ms
+134.170.30.15	people.live.com
+134.170.30.15	profile.live.com
+134.170.111.96	skyapi.onedrive.live.com
 #134.170.104.168	storage.live.com
-#204.79.197.213	nhuhga.dm2301.livefilestore.com
+204.79.197.213	nhuhga.dm2301.livefilestore.com
 # OneDrive End
 
 # SoundCloud Start

--- a/hosts
+++ b/hosts
@@ -3629,17 +3629,17 @@ fe80::1%lo0	localhost
 # MEGA End
 
 # OneDrive Start
-65.55.163.79	account.live.com
+#65.55.163.79	account.live.com
 #204.79.197.217	mail.live.com
-23.59.136.70	auth.gfx.ms
-131.253.61.66	login.live.com
-204.79.197.217	onedrive.live.com
-23.212.129.202	p.sfx.ms
-134.170.30.15	people.live.com
-134.170.30.15	profile.live.com
-134.170.111.96	skyapi.onedrive.live.com
-134.170.104.168	storage.live.com
-204.79.197.213	nhuhga.dm2301.livefilestore.com
+#23.59.136.70	auth.gfx.ms
+#131.253.61.66	login.live.com
+#204.79.197.217	onedrive.live.com
+#23.212.129.202	p.sfx.ms
+#134.170.30.15	people.live.com
+#134.170.30.15	profile.live.com
+#134.170.111.96	skyapi.onedrive.live.com
+#134.170.104.168	storage.live.com
+#204.79.197.213	nhuhga.dm2301.livefilestore.com
 # OneDrive End
 
 # SoundCloud Start

--- a/hosts
+++ b/hosts
@@ -3629,17 +3629,17 @@ fe80::1%lo0	localhost
 # MEGA End
 
 # OneDrive Start
-65.55.163.79	account.live.com
+#65.55.163.79	account.live.com
 #204.79.197.217	mail.live.com
-23.59.136.70	auth.gfx.ms
-131.253.61.66	login.live.com
-204.79.197.217	onedrive.live.com
-23.212.129.202	p.sfx.ms
-134.170.30.15	people.live.com
-134.170.30.15	profile.live.com
-134.170.111.96	skyapi.onedrive.live.com
+#23.59.136.70	auth.gfx.ms
+#131.253.61.66	login.live.com
+#204.79.197.217	onedrive.live.com
+#23.212.129.202	p.sfx.ms
+#134.170.30.15	people.live.com
+#134.170.30.15	profile.live.com
+#134.170.111.96	skyapi.onedrive.live.com
 #134.170.104.168	storage.live.com
-204.79.197.213	nhuhga.dm2301.livefilestore.com
+#204.79.197.213	nhuhga.dm2301.livefilestore.com
 # OneDrive End
 
 # SoundCloud Start


### PR DESCRIPTION
之前的hosts会导致
安卓上onedrive客户端
在有Wifi或4G的时候检测不到网络
不能同步
注释掉之后可以成功同步
