### PR TITLE
Fix aws, then fix Robocraft can't be played BTW.

### DIFF
--- a/hosts
+++ b/hosts
@@ -14,26 +14,26 @@ fe80::1%lo0	localhost
 # Modified hosts start
 
 # Amazon AWS Start
-27.0.1.125	ap-northeast-1.console.aws.amazon.com
+54.239.96.90	ap-northeast-1.console.aws.amazon.com
 54.240.226.19	ap-southeast-1.console.aws.amazon.com
 54.240.195.197	ap-southeast-2.console.aws.amazon.com
 176.32.100.36	aws.amazon.com
 72.21.194.168	console.aws.amazon.com
 54.239.54.107	eu-central-1.console.aws.amazon.com
-178.236.4.251	eu-west-1.console.aws.amazon.com
+# 178.236.4.251	eu-west-1.console.aws.amazon.com
 54.231.66.16	s3.amazonaws.com
 54.231.229.10	s3-ap-northeast-1.amazonaws.com
 54.231.242.150	s3-ap-southeast-1.amazonaws.com
-54.231.252.130	s3-ap-southeast-2.amazonaws.com
-72.21.203.5	s3-console-us-standard.console.aws.amazon.com
+54.231.249.17	s3-ap-southeast-2.amazonaws.com 54.231.249.17
+54.239.31.128	s3-console-us-standard.console.aws.amazon.com
 54.231.192.41	s3-eu-central-1.amazonaws.com
-54.231.132.112	s3-eu-west-1.amazonaws.com
-54.231.253.78	s3-sa-east-1.amazonaws.com
+52.218.16.36	s3-eu-west-1.amazonaws.com
+52.92.74.6	s3-sa-east-1.amazonaws.com
 54.231.237.85	s3-us-west-1.amazonaws.com
-54.231.160.48	s3-us-west-2.amazonaws.com
+54.231.168.216	s3-us-west-2.amazonaws.com
 177.72.244.68	sa-east-1.console.aws.amazon.com
 204.246.162.198	us-west-1.console.aws.amazon.com
-54.240.250.61	us-west-2.console.aws.amazon.com
+# 54.240.250.61	us-west-2.console.aws.amazon.com
 54.231.34.41	github-cloud.s3.amazonaws.com
 54.231.48.40	github-com.s3.amazonaws.com
 # Amazon AWS End

--- a/hosts
+++ b/hosts
@@ -24,7 +24,7 @@ fe80::1%lo0	localhost
 54.231.66.16	s3.amazonaws.com
 54.231.229.10	s3-ap-northeast-1.amazonaws.com
 54.231.242.150	s3-ap-southeast-1.amazonaws.com
-54.231.249.17	s3-ap-southeast-2.amazonaws.com 54.231.249.17
+54.231.249.17	s3-ap-southeast-2.amazonaws.com
 54.239.31.128	s3-console-us-standard.console.aws.amazon.com
 54.231.192.41	s3-eu-central-1.amazonaws.com
 52.218.16.36	s3-eu-west-1.amazonaws.com


### PR DESCRIPTION
郁闷死我了. 没想到 一个月 不能玩的英国游戏 Robocraft, 居然是 aws 引起的. 难道是 英国脱欧的后遗症 (服务器在 London)?