### PR TITLE
Multiple Updates

### DIFF
--- a/hosts
+++ b/hosts
@@ -46,19 +46,9 @@ fe80::1%lo0	localhost
 207.241.226.190	web.archive.org
 # Archive End
 
-# Battle.NET Start
-12.129.206.133	enUS.patch.battle.net
-208.111.148.7	llnw.blizzard.com
-121.254.200.133	zhTW.patch.battle.net
-# Battle.NET End
-
 # Box.com Start
 74.112.184.70	app.box.com
-74.112.184.90	box.com
 74.112.184.85	m.box.com
-104.218.203.34	support.box.com
-74.112.184.85	www.box.com
-74.112.184.80	www.box.net
 # Box.com End
 
 # BundleStars Start
@@ -91,7 +81,7 @@ fe80::1%lo0	localhost
 218.254.1.13	dropbox.com
 218.254.1.13	m.dropbox.com
 218.254.1.13	www.v.dropbox.com
-162.125.66.1	www.dropbox.com
+162.125.65.1	www.dropbox.com
 52.85.76.60	linux.dropbox.com
 108.160.172.193	d.dropbox.com
 108.160.172.193	d.v.dropbox.com
@@ -115,7 +105,7 @@ fe80::1%lo0	localhost
 54.230.214.100	cf.dropboxstatic.com
 54.192.108.33	client-cf.dropbox.com
 45.58.69.38	dl.dropbox.com
-219.76.4.4	dl-web.dropbox.com
+45.58.70.5	dl-web.dropbox.com
 45.58.69.37	dl.dropboxusercontent.com
 162.125.18.2	photos-1.dropbox.com
 162.125.18.2	photos-2.dropbox.com
@@ -134,7 +124,7 @@ fe80::1%lo0	localhost
 108.160.172.236	client.dropbox.com
 108.160.172.236	client.v.dropbox.com
 219.76.4.4	dl-debug.dropbox.com
-219.76.4.4	log.getdropbox.com
+108.160.172.227 log.getdropbox.com
 # Dropbox End
 
 # Facebook start
@@ -252,11 +242,9 @@ fe80::1%lo0	localhost
 104.244.42.3	upload.twitter.com
 104.244.42.3	tweetdeck.twitter.com
 104.244.42.3	syndication.twitter.com
-104.244.42.3	syndication-o.twitter.com
 104.244.42.3	platform.twitter.com
 104.244.42.3	about.twitter.com
 104.244.42.3	blog.twitter.com
-104.244.42.3	p.twitter.com
 104.244.42.3	betastream.twitter.com
 104.244.42.3	dev.twitter.com
 104.244.42.3	pic.twitter.com
@@ -266,6 +254,7 @@ fe80::1%lo0	localhost
 104.244.42.3	assets1.twitter.com
 104.244.42.3	assets2.twitter.com
 104.244.42.3	assets3.twitter.com
+104.244.42.3	assets4.twitter.com
 104.244.42.3	static.twitter.com
 104.244.42.3	help.twitter.com
 104.244.42.3	ton.twitter.com
@@ -288,25 +277,12 @@ fe80::1%lo0	localhost
 173.236.110.98	web7.twitpic.com
 173.236.110.98	web8.twitpic.com
 173.236.110.98	web9.twitpic.com
-209.17.68.209	oi40.tinypic.com
-209.17.68.209	oi41.tinypic.com
-209.17.68.209	oi42.tinypic.com
-209.17.68.209	oi43.tinypic.com
-209.17.68.209	oi44.tinypic.com
-209.17.68.209	oi45.tinypic.com
-209.17.68.209	oi46.tinypic.com
-209.17.68.209	oi47.tinypic.com
-209.17.68.209	oi48.tinypic.com
-209.17.68.209	oi49.tinypic.com
-209.17.68.209	oi50.tinypic.com
-209.17.68.209	oi51.tinypic.com
-209.17.68.209	oi52.tinypic.com
-209.17.68.209	oi53.tinypic.com
-209.17.68.209	oi54.tinypic.com
-209.17.68.209	oi55.tinypic.com
-209.17.68.209	oi56.tinypic.com
 199.96.57.3	a0.twimg.com
 199.96.57.3	a1.twimg.com
+199.96.57.3	a2.twimg.com
+199.96.57.3	a3.twimg.com
+199.96.57.3	a4.twimg.com
+199.96.57.3	a5.twimg.com
 199.96.57.3	video.twimg.com
 199.96.57.3	abs.twimg.com
 199.96.57.3	g.twimg.com
@@ -315,22 +291,10 @@ fe80::1%lo0	localhost
 199.96.57.3	r.twimg.com
 199.96.57.3	ma.twimg.com
 199.96.57.3	pbs.twimg.com
-199.96.57.3	si0.twimg.com
-199.96.57.3	si1.twimg.com
-199.96.57.3	si2.twimg.com
-199.96.57.3	si3.twimg.com
-199.96.57.3	si4.twimg.com
-199.96.57.3	si5.twimg.com
 199.96.57.3	ton.twimg.com
 199.96.57.3	syndication.twimg.com
 199.96.57.3	syndication-o.twimg.com
 199.96.57.3	image-proxy-origin.twimg.com
-199.96.57.3	si0.twimg.co
-199.96.57.3	si1.twimg.co
-199.96.57.3	si2.twimg.co
-199.96.57.3	si3.twimg.co
-199.96.57.3	si4.twimg.co
-199.96.57.3	si5.twimg.co
 104.244.42.132	tweetdeck.com
 104.244.42.132	api.tweetdeck.com
 104.244.42.132	web.tweetdeck.com
@@ -338,9 +302,8 @@ fe80::1%lo0	localhost
 104.244.42.132	downloads.tweetdeck.com
 104.244.42.3	cdn.syndication.twimg.com
 104.244.42.3	cdn.syndication.twitter.com
-104.244.42.3	cdn.api.twitter.com
-104.244.42.3	preview.cdn.twitter.com
 104.244.42.3	apps.twitter.com
+104.244.42.3  debates.twitter.com
 # Twitter End
 
 # Gmail web Start
@@ -601,28 +564,6 @@ fe80::1%lo0	localhost
 220.255.2.153	developers.googleblog.com
 220.255.2.153	books.google.com
 220.255.2.153	books.google.com.hk
-220.255.2.153	bks0.books.google.com
-220.255.2.153	bks1.books.google.com
-220.255.2.153	bks2.books.google.com
-220.255.2.153	bks3.books.google.com
-220.255.2.153	bks4.books.google.com
-220.255.2.153	bks5.books.google.com
-220.255.2.153	bks6.books.google.com
-220.255.2.153	bks7.books.google.com
-220.255.2.153	bks8.books.google.com
-220.255.2.153	bks9.books.google.com
-220.255.2.153	bks10.books.google.com
-220.255.2.153	bks0.books.google.com.hk
-220.255.2.153	bks1.books.google.com.hk
-220.255.2.153	bks2.books.google.com.hk
-220.255.2.153	bks3.books.google.com.hk
-220.255.2.153	bks4.books.google.com.hk
-220.255.2.153	bks5.books.google.com.hk
-220.255.2.153	bks6.books.google.com.hk
-220.255.2.153	bks7.books.google.com.hk
-220.255.2.153	bks8.books.google.com.hk
-220.255.2.153	bks9.books.google.com.hk
-220.255.2.153	bks10.books.google.com.hk
 220.255.2.153	buzz.google.com
 220.255.2.153	calendar.google.com
 220.255.2.153	checkout.google.com
@@ -806,13 +747,6 @@ fe80::1%lo0	localhost
 220.255.2.153	ditu.google.com
 220.255.2.153	maps-api-ssl.google.com
 220.255.2.153	map.google.com
-220.255.2.153	kh.google.com
-220.255.2.153	khmdb.google.com
-220.255.2.153	khm.google.com
-220.255.2.153	khm0.google.com
-220.255.2.153	khm1.google.com
-220.255.2.153	khm2.google.com
-220.255.2.153	khm3.google.com
 220.255.2.153	cbk0.google.com
 220.255.2.153	cbk1.google.com
 220.255.2.153	cbk2.google.com
@@ -852,23 +786,6 @@ fe80::1%lo0	localhost
 220.255.2.153	orkut.google.com
 220.255.2.153	www.orkut.com
 220.255.2.153	www.orkut.gmodules.com
-220.255.2.153	img1.orkut.com
-220.255.2.153	img2.orkut.com
-220.255.2.153	img3.orkut.com
-220.255.2.153	img4.orkut.com
-220.255.2.153	img5.orkut.com
-220.255.2.153	img6.orkut.com
-220.255.2.153	img7.orkut.com
-220.255.2.153	img8.orkut.com
-220.255.2.153	img9.orkut.com
-220.255.2.153	static1.orkut.com
-220.255.2.153	static2.orkut.com
-220.255.2.153	static3.orkut.com
-220.255.2.153	static4.orkut.com
-220.255.2.153	promote.orkut.com
-220.255.2.153	help.orkut.com
-220.255.2.153	blog.orkut.com
-220.255.2.153	en.blog.orkut.com
 220.255.2.153	pack.google.com
 220.255.2.153	cache.pack.google.com
 220.255.2.153	photos.google.com
@@ -883,9 +800,7 @@ fe80::1%lo0	localhost
 220.255.2.153	profiles.google.com
 220.255.2.153	plusone.google.com
 220.255.2.153	plus.google.com
-220.255.2.153	plus.google.com.hk
 220.255.2.153	plus.url.google.com
-220.255.2.153	plus.url.google.com.hk
 220.255.2.153	spaces.google.com
 220.255.2.153	pixel.google.com
 220.255.2.153	madeby.google.com
@@ -1140,16 +1055,13 @@ fe80::1%lo0	localhost
 220.255.2.153	appspot.l.google.com
 220.255.2.153	aspmx.l.google.com
 220.255.2.153	b.googlemail.l.google.com
-220.255.2.153	bandaid-redirector.l.google.com
 220.255.2.153	blogger.l.google.com
 220.255.2.153	bloggerphotos.l.google.com
 220.255.2.153	browsersync.l.google.com
 220.255.2.153	browserchannel-docs.l.google.com
-220.255.2.153	cache.l.google.com
 220.255.2.153	cbk.l.google.com
 220.255.2.153	code.l.google.com
 220.255.2.153	checkout.l.google.com
-220.255.2.153	chromeecho.l.google.com
 220.255.2.153	clients.l.google.com
 220.255.2.153	clients-cctld.l.google.com
 220.255.2.153	csi.l.google.com
@@ -1158,7 +1070,6 @@ fe80::1%lo0	localhost
 220.255.2.153	encrypted-tbn.l.google.com
 220.255.2.153	gadgets.l.google.com
 220.255.2.153	googleapis.l.google.com
-220.255.2.153	googleapis-ajax.l.google.com
 220.255.2.153	googlecode.l.google.com
 220.255.2.153	googlehosted.l.google.com
 220.255.2.153	groups.l.google.com
@@ -1166,10 +1077,6 @@ fe80::1%lo0	localhost
 220.255.2.153	id.l.google.com
 220.255.2.153	images.l.google.com
 220.255.2.153	ipv4.l.google.com
-220.255.2.153	keyhole.l.google.com
-220.255.2.153	kh.l.google.com
-220.255.2.153	khm.l.google.com
-220.255.2.153	khmdb.l.google.com
 220.255.2.153	khms.l.google.com
 220.255.2.153	large-uploads.l.google.com
 220.255.2.153	maps.l.google.com
@@ -1181,15 +1088,7 @@ fe80::1%lo0	localhost
 220.255.2.153	mw-medium.l.google.com
 220.255.2.153	mw-small.l.google.com
 220.255.2.153	news.l.google.com
-220.255.2.153	orkut-fe.l.google.com
-220.255.2.153	orkut-images.l.google.com
-220.255.2.153	orkut-opensocial.l.google.com
-220.255.2.153	orkut-promote.l.google.com
-220.255.2.153	orkut-static.l.google.com
-220.255.2.153	pagead.l.google.com
 220.255.2.153	pagead-tpc.l.google.com
-220.255.2.153	pagead-googlehosted.l.google.com
-220.255.2.153	partnerad.l.google.com
 220.255.2.153	picasaweb.l.google.com
 220.255.2.153	plus.l.google.com
 220.255.2.153	photos-ugc.l.google.com
@@ -1202,7 +1101,6 @@ fe80::1%lo0	localhost
 220.255.2.153	spreadsheets.l.google.com
 220.255.2.153	spreadsheets-china.l.google.com
 220.255.2.153	sslvideo-upload.l.google.com
-220.255.2.153	static.cache.l.google.com
 220.255.2.153	suggestqueries.l.google.com
 220.255.2.153	tbn.l.google.com
 220.255.2.153	toolbarqueries.l.google.com
@@ -1216,31 +1114,6 @@ fe80::1%lo0	localhost
 220.255.2.153	www0.l.google.com
 220.255.2.153	www1.l.google.com
 220.255.2.153	googlemashups.l.google.com
-220.255.2.153	qwqy.vp.video.l.google.com
-220.255.2.153	nz.vp.video.l.google.com
-220.255.2.153	nztdug.vp.video.l.google.com
-220.255.2.153	pr.vp.video.l.google.com
-220.255.2.153	ug.vp.video.l.google.com
-220.255.2.153	vp01.video.l.google.com
-220.255.2.153	vp02.video.l.google.com
-220.255.2.153	vp03.video.l.google.com
-220.255.2.153	vp04.video.l.google.com
-220.255.2.153	vp05.video.l.google.com
-220.255.2.153	vp06.video.l.google.com
-220.255.2.153	vp07.video.l.google.com
-220.255.2.153	vp08.video.l.google.com
-220.255.2.153	vp09.video.l.google.com
-220.255.2.153	vp10.video.l.google.com
-220.255.2.153	vp11.video.l.google.com
-220.255.2.153	vp12.video.l.google.com
-220.255.2.153	vp13.video.l.google.com
-220.255.2.153	vp14.video.l.google.com
-220.255.2.153	vp15.video.l.google.com
-220.255.2.153	vp16.video.l.google.com
-220.255.2.153	vp17.video.l.google.com
-220.255.2.153	vp18.video.l.google.com
-220.255.2.153	vp19.video.l.google.com
-220.255.2.153	vp20.video.l.google.com
 220.255.2.153	video-stats.l.google.com
 220.255.2.153	video-analytics.l.google.com
 220.255.2.153	video-thumbnails.l.google.com

--- a/hosts
+++ b/hosts
@@ -124,7 +124,7 @@ fe80::1%lo0	localhost
 108.160.172.236	client.dropbox.com
 108.160.172.236	client.v.dropbox.com
 219.76.4.4	dl-debug.dropbox.com
-108.160.172.227 log.getdropbox.com
+108.160.172.227	log.getdropbox.com
 # Dropbox End
 
 # Facebook start
@@ -303,7 +303,7 @@ fe80::1%lo0	localhost
 104.244.42.3	cdn.syndication.twimg.com
 104.244.42.3	cdn.syndication.twitter.com
 104.244.42.3	apps.twitter.com
-104.244.42.3  debates.twitter.com
+104.244.42.3	debates.twitter.com
 # Twitter End
 
 # Gmail web Start


### PR DESCRIPTION
1. Battle.net works fine now. No need to be redirected anymore.
2. Some domains of box.com can be resolved correctly. So deleted them.
3. Replaced some ips used for dropbox.com by official ones.
4. Twitter: Deleted some NX domains and added some. Deleted tinypic.com & twimg.co because they can be correctly resolved.
5. Google: Deleted books, video, orkut, HK plus and some l.google (NX) domains. Keyhole service (kh, khm, khmdb) and some pagead services are redirected to Google China, so deleted either.