### PR TITLE
2016/12/07 fix cdn of twitter

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, racaljk.
 # https://github.com/racaljk/hosts
-# Last updated: 2016-12-02
+# Last updated: 2016-12-07
 
 # This work is licensed under a CC BY-NC-SA 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -3243,24 +3243,24 @@
 173.236.110.98	web7.twitpic.com
 173.236.110.98	web8.twitpic.com
 173.236.110.98	web9.twitpic.com
-199.96.57.3	a0.twimg.com
-199.96.57.3	a1.twimg.com
-199.96.57.3	a2.twimg.com
-199.96.57.3	a3.twimg.com
-199.96.57.3	a4.twimg.com
-199.96.57.3	a5.twimg.com
-199.96.57.3	video.twimg.com
-199.96.57.3	abs.twimg.com
-199.96.57.3	g.twimg.com
-199.96.57.3	o.twimg.com
-199.96.57.3	p.twimg.com
-199.96.57.3	r.twimg.com
-199.96.57.3	ma.twimg.com
-199.96.57.3	pbs.twimg.com
-199.96.57.3	ton.twimg.com
-199.96.57.3	syndication.twimg.com
-199.96.57.3	syndication-o.twimg.com
-199.96.57.3	image-proxy-origin.twimg.com
+110.4.24.178	a0.twimg.com
+110.4.24.178	a1.twimg.com
+110.4.24.178	a2.twimg.com
+110.4.24.178	a3.twimg.com
+110.4.24.178	a4.twimg.com
+110.4.24.178	a5.twimg.com
+110.4.24.178	video.twimg.com
+110.4.24.178	abs.twimg.com
+110.4.24.178	g.twimg.com
+110.4.24.178	o.twimg.com
+110.4.24.178	p.twimg.com
+110.4.24.178	r.twimg.com
+110.4.24.178	ma.twimg.com
+110.4.24.178	pbs.twimg.com
+110.4.24.178	ton.twimg.com
+110.4.24.178	syndication.twimg.com
+110.4.24.178	syndication-o.twimg.com
+110.4.24.178	image-proxy-origin.twimg.com
 104.244.42.132	tweetdeck.com
 104.244.42.132	api.tweetdeck.com
 104.244.42.132	web.tweetdeck.com


### PR DESCRIPTION
修复twitter的静态文件地址失效导致无法加载js和css，页面layout后没有样式