### PR TITLE
fix typo

### DIFF
--- a/hosts
+++ b/hosts
@@ -3129,7 +3129,7 @@
 23.38.96.57	read.kobobooks.com
 23.38.96.57	secure.kobobooks.com
 23.38.96.57	services.kobobooks.com
-23.38.96.57	store.kobobooks.
+23.38.96.57	store.kobobooks.com
 23.38.96.57	tr.kobobooks.com
 23.38.96.57	webstore.kobobooks.com
 23.38.96.57	webstore2.kobobooks.com


### PR DESCRIPTION
store.kobobooks. is store.kobobooks.com
