### PR TITLE
Fix TensorFlow.

### DIFF
--- a/hosts
+++ b/hosts
@@ -574,7 +574,6 @@
 61.91.161.217	fuchsia.googlesource.com
 61.91.161.217	googlesource.com
 61.91.161.217	boringssl.googlesource.com
-108.177.97.82	tensorflow.googlesource.com
 61.91.161.217	gerrit.googlesource.com
 61.91.161.217	gerrit-review.googlesource.com
 61.91.161.217	chromium.googlesource.com
@@ -2784,7 +2783,7 @@
 61.91.161.217	abc.xyz
 64.233.191.121	www.androidexperiments.com
 64.233.191.121	androidexperiments.com
-64.233.188.121	www.tensorflow.org
+61.91.161.217	www.tensorflow.org
 # Google:others End
 
 # Gmail SMTP/POP/IMAP Start


### PR DESCRIPTION
Remove "tensorflow.googlesource.com" since this project is now hosted on GitHub.
Update IP address for "www.tensorflow.org".

Fix #1029.