### PR TITLE
修正lhosts脚本中sed命令在Mac下抛异常的bug

### DIFF
--- a/tools/lhosts
+++ b/tools/lhosts
@@ -73,7 +73,12 @@ get_hosts()
 	fi
 
 	# Add range mark
-	sed -e "1 i\\$BEGIN_MARK" -e "$ a\\$END_MARK" "$REMOTE_FILE" > "$swp"
+	if [ "$(uname)" == "Darwin" ]; then
+        	sed -e '1 i\'$'\n'"$BEGIN_MARK" -e '$ a\'$'\n'"$END_MARK" "$REMOTE_FILE" > "$swp"
+    	else
+		sed -e "1 i\\$BEGIN_MARK" -e "$ a\\$END_MARK" "$REMOTE_FILE" > "$swp"
+	fi
+
 	mv -f "$swp" "$REMOTE_FILE"
 }
 


### PR DESCRIPTION
修正lhosts脚本中sed命令在Mac下抛异常的bug。
抛出的异常内容：sed: 1: "1 i\# 远程 hosts 开? ...": extra characters after \ at the end of i command

您好，感谢您开Pull Request来提供帮助，在提交前，请确保您已经检查了以下内容!
- [x] 没有无用commit（向Git仓库引入奇怪的东西）
- [x] 确认更新有效以及更新的来源并遵守相关许可协议
- [x] 部分Hosts Tool的问题请及时与相关作者联系
- [x] hosts文件中ip与域名间是用`	`(Tab)分隔而不是空格
- [x] 更新hosts文件后请及时修改更新时间
