### PR TITLE
add Resilio Sync

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -4314,3 +4314,9 @@ hosts:
           - youtubei.googleapis.com
           - youtube-ui.l.google.com
           - www.youtube-nocookie.com
+
+  - name: Resilio Sync
+    items:
+      - ip: 54.230.143.112
+        domains:
+          - config.getsync.com


### PR DESCRIPTION
add Resilio Sync
解决 Resilio Sync 软件无法获取追踪器列表的问题
