### PR TITLE
Add api.telegram.org for telegram bots

### DIFF
--- a/hosts
+++ b/hosts
@@ -3655,6 +3655,7 @@
 149.154.167.124	vesta-1.web.telegram.org
 149.154.171.22	flora.web.telegram.org
 149.154.171.22	flora-1.web.telegram.org
+149.154.167.200 api.telegram.org
 # telegram End
 
 # thebodyshop Start


### PR DESCRIPTION
solves problems like 
```
I/O exception (java.net.NoRouteToHostException) caught when processing request to {s}->https://api.telegram.org:443: No route to host
```

您好，感谢您开Pull Request来提供帮助，在提交前，请确保您已经检查了以下内容!
- [x] 没有无用commit（向Git仓库引入奇怪的东西）
- [x] 确认更新有效以及更新的来源并遵守相关许可协议
- [x] 部分Hosts Tool的问题请及时与相关作者联系
